### PR TITLE
feat: capitalized display names instead of usernames

### DIFF
--- a/src/modules/Chat/TwurpleChat.ts
+++ b/src/modules/Chat/TwurpleChat.ts
@@ -32,7 +32,7 @@ export class TwurpleChat implements ChatInterface {
 
       callback({
         id: data.id,
-        user: user,
+        user: data.userInfo.displayName || user,
         color: color,
         message: parsedMessage,
         date: data.date


### PR DESCRIPTION
This PR updates the chat to display Twitch display names instead of usernames.

The username is always lowercase, while the display name allows capitalization based on the user's preferences (e.g., `username` vs. `UserName`). Using display names ensures that names are shown as users intend, matching how they appear in Twitch chat.